### PR TITLE
Fix binarize filter parameters

### DIFF
--- a/receipt_scanner/image/filters/binarize.py
+++ b/receipt_scanner/image/filters/binarize.py
@@ -10,15 +10,11 @@ logger = getLogger(__name__)
 
 
 class BinarizeFilter(Filter):
-    def __init__(self, sigma: float = 0.33, debug: bool = False) -> None:
-        self.sigma = sigma
+    def __init__(self, debug: bool = False) -> None:
         self.debug = debug
 
     def eval(self, image: np.ndarray) -> np.ndarray:
         logger.debug("Applying 'BinarizeFilter'...")
-        median = np.median(image)
-        lower = int(max(0, (1.0 - self.sigma) * median))
-        upper = int(min(255, (1.0 + self.sigma) * median))
-        _, binarized_image = cv2.threshold(image, lower, upper, cv2.THRESH_BINARY)
+        _, binarized_image = cv2.threshold(image, 168, 255, cv2.THRESH_BINARY)
         debug_show(binarized_image, debug=self.debug)
         return binarized_image


### PR DESCRIPTION
## Description

Fix the binarize filter parameters to ones that seem to work perfectly with any decent image (`168` for the lower threshold, `255` for the color)

## Requirements

None.

## Additional changes

None.
