### PR TITLE
Allow charset specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ You can also use `receipt-scanner` as a CLI! Once installed, the `scanner` comma
 scanner --image path/to/some/image.jpg --expression "([0-9]+\.[0-9]+)" --debug
 ```
 
+### Specifying allowed characters
+
+By default, the library will use for the following characters:
+
+```py
+DEFAULT_ALLOWED_CHARACTERS = (
+    "ABCDEFGHIJKLMNÑOPQRSTUVWXYZabcdefghijklmnñopqrstuvwxyz1234567890\ "
+)
+```
+
+Notice that the last "\ " represents the space character.
+
+You can pass a set of allowed characters to the engine, either by using the `--characters` flag when using the CLI or by passing the `allowed_characters` attribute to the `scan` method of the library.
+
 ### Debugging
 
 The `debug` flag will show logs of every step, and will freeze each image manipulation step to show the result of said manipulation. This can be useful to understand why the `scan` command might be returning an empty list, for example (you might find that the image has poor contrast and that the contour of the receipt is not being correctly mapped).

--- a/receipt_scanner/cli.py
+++ b/receipt_scanner/cli.py
@@ -8,6 +8,7 @@ from receipt_scanner.core import scan
 
 class Arguments(TypedDict):
     image_location: str
+    allowed_characters: str | None
     regular_expression: re.Pattern | None
     debug: bool
 
@@ -31,6 +32,14 @@ def generate_parser() -> argparse.ArgumentParser:
         "--image",
         dest="image_location",
         help="Location of the receipt image (can be a local path or a URL).",
+    )
+
+    # Allowed Characters
+    parser.add_argument(
+        "-c",
+        "--characters",
+        dest="allowed_characters",
+        help="Characters allowed to be identified from the image.",
     )
 
     # Regular Expression
@@ -67,6 +76,7 @@ def process_parser(parser: argparse.ArgumentParser) -> Arguments:
     arguments_namespace = parser.parse_args()
     return {
         "image_location": arguments_namespace.image_location,
+        "allowed_characters": arguments_namespace.allowed_characters,
         "regular_expression": (
             re.compile(arguments_namespace.regular_expression)
             if arguments_namespace.regular_expression

--- a/receipt_scanner/core.py
+++ b/receipt_scanner/core.py
@@ -8,10 +8,11 @@ from receipt_scanner.parser import filter_text
 
 def scan(
     image_location: str,
+    allowed_characters: str | None = None,
     regular_expression: re.Pattern | None = None,
     debug: bool = False,
 ) -> list[str]:
     configure_logger(debug=debug)
     image = process_image(image_location, debug=debug)
-    text = get_text(image)
+    text = get_text(image, allowed_characters=allowed_characters)
     return filter_text(text, regular_expression)

--- a/receipt_scanner/image_to_text.py
+++ b/receipt_scanner/image_to_text.py
@@ -15,8 +15,6 @@ def get_text(image: np.ndarray, allowed_characters: str | None) -> str:
     logger.debug("Extracting text from image...")
     charset = allowed_characters or DEFAULT_ALLOWED_CHARACTERS
     options = {
-        "config": (
-            f"--psm 4 -c tessedit_char_whitelist={charset} " "-l spa+eng"
-        ),
+        "config": f"--psm 4 -c tessedit_char_whitelist={charset} -l spa+eng",
     }
     return pytesseract.image_to_string(image, **options)

--- a/receipt_scanner/image_to_text.py
+++ b/receipt_scanner/image_to_text.py
@@ -7,7 +7,7 @@ logger = getLogger(__name__)
 
 
 ALLOWED_CHARACTERS = (
-    "ABCDEFGHIJKLMNÑOPQRSTUVWXYZabcdefghijklmnñopqrstuvwxyz1234567890\ .#+-:"
+    "ABCDEFGHIJKLMNÑOPQRSTUVWXYZabcdefghijklmnñopqrstuvwxyz1234567890\ "
 )
 
 

--- a/receipt_scanner/image_to_text.py
+++ b/receipt_scanner/image_to_text.py
@@ -6,16 +6,17 @@ import pytesseract
 logger = getLogger(__name__)
 
 
-ALLOWED_CHARACTERS = (
+DEFAULT_ALLOWED_CHARACTERS = (
     "ABCDEFGHIJKLMNÑOPQRSTUVWXYZabcdefghijklmnñopqrstuvwxyz1234567890\ "
 )
 
 
-def get_text(image: np.ndarray) -> str:
+def get_text(image: np.ndarray, allowed_characters: str | None) -> str:
     logger.debug("Extracting text from image...")
+    charset = allowed_characters or DEFAULT_ALLOWED_CHARACTERS
     options = {
         "config": (
-            f"--psm 4 -c tessedit_char_whitelist={ALLOWED_CHARACTERS} " "-l spa+eng"
+            f"--psm 4 -c tessedit_char_whitelist={charset} " "-l spa+eng"
         ),
     }
     return pytesseract.image_to_string(image, **options)


### PR DESCRIPTION
## Description

Now there is a CLI flag and a parameter for the `scan` method to specify the allowed characters for the receipt

## Requirements

None.

## Additional changes

The default characters have also changed, removing every non-alphanumeric character.
