### PR TITLE
Add docker tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Exclude: everything
+*
+
+# Include: application files
+!receipt_scanner
+
+# Include: build files
+!pyproject.toml
+!poetry.lock
+
+# Include: misc files
+!docker/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -75,13 +75,39 @@ The `debug` flag will show logs of every step, and will freeze each image manipu
 
 ## Developing
 
-### Requirements
+### Using Docker
+
+You can use Docker to run the CLI without the need to install Poetry nor Tesseract (+ Tesseract Spanish). A Docker configuration has already been provided. All you have to do is follow this steps:
+
+Clone the repository:
+
+```sh
+git clone https://github.com/daleal/receipt-scanner.git
+
+cd receipt-scanner
+```
+
+Then, build the container image:
+
+```sh
+docker compose build
+```
+
+Now you can use the CLI through Compose:
+
+```sh
+docker compose run scanner --help
+```
+
+### Without Docker
+
+#### Requirements
 
 - [Poetry](https://python-poetry.org)
 - [Tesseract](https://tesseract-ocr.github.io/tessdoc/Installation.html)
 - [Teseract Spanish](https://parzibyte.me/blog/2019/05/18/instalar-tesseract-ocr-idioma-espanol-ubuntu)
 
-### Steps
+#### Steps
 
 Clone the repository:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  scanner:
+    init: true
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    command: scanner
+    volumes:
+      - .:/scanner

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,59 @@
+FROM python:3.10-slim-buster AS environment
+
+ENV LANG=C.UTF-8 \
+    # python:
+    PYTHONFAULTHANDLER=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random \
+    # pip
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    # poetry
+    POETRY_VERSION=1.1.13
+
+WORKDIR /scanner
+
+RUN apt-get update \
+    && apt-get install -y libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install "poetry==$POETRY_VERSION"
+
+RUN python -m venv /venv
+
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry export --format requirements.txt --output fulldependencies.txt --without-hashes && \
+    /venv/bin/pip install --requirement fulldependencies.txt && \
+    rm fulldependencies.txt
+
+# --------------------------------------------------------
+
+FROM python:3.10-slim-buster AS final
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update \
+    && apt-get install -y \
+        libgl1-mesa-dev \
+        libtesseract-dev \
+        tesseract-ocr \
+        tesseract-ocr-spa \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /scanner
+
+COPY --from=environment /venv /venv
+
+ENV PATH="/venv/bin:$PATH"
+
+COPY docker/entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
+COPY . .
+
+# Run as non-root user
+RUN useradd -m non-root-user
+USER non-root-user

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Activate virtual env
+. /venv/bin/activate
+
+exec "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,13 @@ packages = [
 ]
 exclude = [
     ".github",
+    ".dockerignore",
     ".flake8",
     ".pylintrc",
+    "docker-compose.yml",
     "mypy.ini",
     "Makefile",
+    "docker",
     "scripts"
 ]
 


### PR DESCRIPTION
## Description

This PR adds a Docker configuration for testing the CLI locally (for development) without the need to install Tesseract.

## Requirements

🐳.

## Additional changes

None.
